### PR TITLE
Fix docker container inspect error

### DIFF
--- a/mrbgem/mrblib/docker.rb
+++ b/mrbgem/mrblib/docker.rb
@@ -30,6 +30,7 @@ module Docker
       def all
         @all ||= begin
           ids = `docker ps -q --no-trunc`.lines.map(&:chomp)
+          return [] if ids.empty?
           data = JSON.parse(`docker container inspect #{ids.join(' ')}`)
           data.map do |d|
             new(d)


### PR DESCRIPTION
```
app_1    | "docker container inspect" requires at least 1 argument(s).
app_1    | See 'docker container inspect --help'.
app_1    |
app_1    | Usage:  docker container inspect [OPTIONS] CONTAINER [CONTAINER...]
app_1    |
app_1    | Display detailed information on one or more containers
app_1    | nginx: [error] mrb_run failed. error: INLINE CODE:4: invalid json (JSON::ParserError) in /usr/local/nginx/conf/nginx.conf:21
```