### PR TITLE
Update CSS + Add Dark Theme

### DIFF
--- a/hook/index.rb
+++ b/hook/index.rb
@@ -22,7 +22,7 @@ Nginx.echo <<-HTML
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta http-equiv="Content-Style-Type" content="text/css" />
     <title>Yaichi</title>
-    <link rel="stylesheet" href="https://cdn.rawgit.com/andyferra/2554919/raw/2e66cabdafe1c9a7f354aa2ebf5bc38265e638e5/github.css" type="text/css" />
+    <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css" type="text/css" />
     <link rel="icon" type="image/png" href="/favicon.png">
   </head>
   <body>

--- a/hook/index.rb
+++ b/hook/index.rb
@@ -22,17 +22,45 @@ Nginx.echo <<-HTML
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta http-equiv="Content-Style-Type" content="text/css" />
     <title>Yaichi</title>
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css" type="text/css" />
     <link rel="icon" type="image/png" href="/favicon.png">
+
+    <style>
+      .switcher {
+        position: fixed;
+        right: 20px;
+        bottom: 20px;
+        width: auto;
+        margin-bottom: 0;
+        padding: 0.75rem;
+        border-radius: 2rem;
+        box-shadow: var(--card-box-shadow);
+        line-height: 1;
+        text-align: right;
+      }
+
+      .switcher::after {
+        display: inline-block;
+        width: 1rem;
+        height: 1rem;
+        border: 0.15rem solid currentColor;
+        border-radius: 50%;
+        background: linear-gradient(to right,currentColor 0,currentColor 50%,transparent 50%);
+        content: "";
+        vertical-align: bottom;
+        transition: transform var(--transition);
+      }
+    </style>
   </head>
-  <body>
+  <body style="padding:20px">
     <a href="https://github.com/mtsmfm/yaichi">
       <img style="position: absolute; top: 0; right: 0; border: 0;"
         src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67"
         alt="Fork me on GitHub"
       data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
     </a>
-    <h1>Proxy-able Containers</h1>
+    <h2>Proxy-able Containers</h2>
     <ul>
     #{
       containers.flat_map do |c|
@@ -42,12 +70,31 @@ Nginx.echo <<-HTML
       end.join("\n")
     }
     </ul>
-    <h1>All Containers</h1>
+    <h2>All Containers</h2>
     <ul>
     #{
       containers.map {|c| "<li>#{c.name}</li>" }.join("\n")
     }
     </ul>
+
+    <button class="contrast switcher" onclick="toggleTheme()"></button>
+
+    <script>
+      function toggleTheme() {
+        if (Cookies.get('theme') == 'dark') {
+          setTheme('light')
+        } else {
+          setTheme('dark')
+        }
+      }
+
+      function setTheme(theme) {
+        Cookies.set('theme', theme)
+        document.querySelector('html').setAttribute('data-theme', theme)
+      }
+
+      setTheme(Cookies.get('theme') || 'light')
+    </script>
   </body>
 </html>
 HTML


### PR DESCRIPTION
The current CSS used in Yaichi is not accessible anymore, the CDN url is returning 502 Bad Gateway:

https://github.com/mtsmfm/yaichi/blob/69231842dc78676277d3f70574f3d510aeac6067/hook/index.rb#L25

---

I replaced it with lightweight CSS library https://picocss.com/ and added (switchable) dark theme as well:

| Light Mode | Dark Mode |
| --- | --- |
| ![Screenshot from 2022-02-08 18-18-26](https://user-images.githubusercontent.com/6077598/152977908-0d83be25-c896-45fd-bd25-20fcd0475b22.png) | ![Screenshot from 2022-02-08 18-18-04](https://user-images.githubusercontent.com/6077598/152977940-4f42456d-b663-4bf4-8374-4357487a378d.png)